### PR TITLE
🩹 [Patch]: Use `GitHub-Script` action

### DIFF
--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Get issue file content
         id: GetIssueFileContent
-        uses: GitHub-Script@v1
+        uses: PSModule/GitHub-Script@v1
         with:
           Script: |
             $issueFileContent = Get-Content -Path tests/IssueBody.md -Raw

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -27,23 +27,17 @@ jobs:
 
       - name: Get issue file content
         id: GetIssueFileContent
-        shell: pwsh
-        run: |
-          $issueFileContent = Get-Content -Path tests/IssueBody.md -Raw
-
-          $EOF = -join (1..15 | ForEach {[char]((48..57)+(65..90)+(97..122) | Get-Random)})
-          "issueFileContent<<$EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          $issueFileContent | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          "$EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-
-      - uses: PSModule/Debug@v0
-        if: always()
+        uses: GitHub-Script@v1
+        with:
+          Script: |
+            $issueFileContent = Get-Content -Path tests/IssueBody.md -Raw
+            Set-GitHubOutput -Name 'issueFileContent' -Value $issueFileContent
 
       - name: Action-Test
         id: Action-Test
         uses: ./
         with:
-          IssueBody: ${{ steps.GetIssueFileContent.outputs.issueFileContent }}
+          IssueBody: ${{ fromJson(steps.GetIssueFileContent.outputs.result).issueFileContent }}
 
       - name: Action-Test-Results
         shell: pwsh

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -30,8 +30,11 @@ jobs:
         uses: PSModule/GitHub-Script@v1
         with:
           Script: |
-            $issueFileContent = Get-Content -Path tests/IssueBody.md -Raw
-            Set-GitHubOutput -Name 'issueFileContent' -Value $issueFileContent
+            LogGroup 'Get Issue File Content' {
+              $issueFileContent = Get-Content -Path tests/IssueBody.md -Raw
+              $issueFileContent
+              Set-GitHubOutput -Name 'issueFileContent' -Value $issueFileContent
+            }
 
       - name: Action-Test
         id: Action-Test

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -29,12 +29,7 @@ jobs:
         id: GetIssueFileContent
         uses: PSModule/GitHub-Script@v1
         with:
-          Script: |
-            LogGroup 'Get Issue File Content' {
-              $issueFileContent = Get-Content -Path tests/IssueBody.md -Raw
-              $issueFileContent
-              Set-GitHubOutput -Name 'issueFileContent' -Value $issueFileContent
-            }
+          Script: . '.\tests\Get-IssueFileContent.ps1'
 
       - name: Action-Test
         id: Action-Test

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ jobs:
     steps:
       - name: Get-IssueFormData
         id: Get-IssueFormData
-        uses: PSModule/Get-IssueFormData@v0
+        uses: PSModule/Get-IssueFormData@v1
 
       - name: Print data
         shell: pwsh

--- a/action.yml
+++ b/action.yml
@@ -14,16 +14,15 @@ inputs:
 outputs:
   data:
     description: The data from the issue body
-    value: ${{ steps.Get-IssueFormData.outputs.data }}
+    value: ${{ fromJson(steps.Get-IssueFormData.outputs.result).data }}
 
 runs:
   using: composite
   steps:
     - name: Get-IssueFormData
       id: Get-IssueFormData
-      shell: pwsh
+      uses: PSModule/GitHub-Script@v1
       env:
         GITHUB_ACTION_INPUT_IssueBody: ${{ inputs.IssueBody }}
-      run: |
-        # Get-IssueFormData
-        . "${{ github.action_path }}\scripts\main.ps1" -Verbose
+      with:
+        Script: . (Join-Path -Path '${{ github.action_path }}' -ChildPath 'scripts\main.ps1')

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -114,19 +114,15 @@ filter Process-IssueBody {
     $data
 }
 
-Write-Host '::group::Issue Body'
-$IssueBody
-Write-Host '::endgroup::'
+LogGroup 'Issue Body' {
+    Write-Output $IssueBody
+}
 
-Write-Host '::group::Issue Body Split'
-# Read the content of the file
-
-$data = $IssueBody | Parse-IssueBody | Process-IssueBody
-# Output the results
-$data | Format-Table -AutoSize
-
-$data = $data | ConvertTo-Json -Compress
-$data
-"data=$data" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-
-Write-Host '::endgroup::'
+LogGroup 'Issue Body Split' {
+    $data = $IssueBody | Parse-IssueBody | Process-IssueBody
+    # Output the results
+    $data | Format-Table -AutoSize
+    $data = $data | ConvertTo-Json -Compress
+    Write-Output $data
+    Set-GitHubOutput -Name 'data' -Value $data
+}

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -114,14 +114,16 @@ filter Process-IssueBody {
     $data
 }
 
-LogGroup 'Issue Body' {
+LogGroup 'Issue Body - Raw' {
     Write-Output $IssueBody
 }
 
-LogGroup 'Issue Body Split' {
+LogGroup 'Issue Body - Object' {
     $data = $IssueBody | Parse-IssueBody | Process-IssueBody
-    # Output the results
     $data | Format-Table -AutoSize
+}
+
+LogGroup 'Issue Body - JSON' {
     $data = $data | ConvertTo-Json -Compress
     Write-Output $data
     Set-GitHubOutput -Name 'data' -Value $data

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -120,9 +120,6 @@ LogGroup 'Issue Body' {
 
 LogGroup 'Issue Body Split' {
     $data = $IssueBody | Parse-IssueBody | Process-IssueBody
-    # Output the results
     $data | Format-Table -AutoSize
-    $data = $data | ConvertTo-Json -Compress
-    Write-Output $data
     Set-GitHubOutput -Name 'data' -Value $data
 }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -120,6 +120,9 @@ LogGroup 'Issue Body' {
 
 LogGroup 'Issue Body Split' {
     $data = $IssueBody | Parse-IssueBody | Process-IssueBody
+    # Output the results
     $data | Format-Table -AutoSize
+    $data = $data | ConvertTo-Json -Compress
+    Write-Output $data
     Set-GitHubOutput -Name 'data' -Value $data
 }

--- a/tests/Get-IssueFileContent.ps1
+++ b/tests/Get-IssueFileContent.ps1
@@ -1,0 +1,5 @@
+﻿LogGroup 'Get Issue File Content' {
+    $issueFileContent = Get-Content -Path tests/IssueBody.md -Raw
+    $issueFileContent
+    Set-GitHubOutput -Name 'issueFileContent' -Value $issueFileContent
+}


### PR DESCRIPTION
## Description

This pull request changes the action to use the `GitHub-Script` action, to make use of built in functions in the GitHub PowerShell module:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L17-R28): Modified the `Get-IssueFormData` step to use the `PSModule/GitHub-Script@v1` module and updated the method for setting the output data.
* [`scripts/main.ps1`](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011L117-R128): Replaced direct output commands with `LogGroup` and `Set-GitHubOutput` functions.
* [`.github/workflows/Action-Test.yml`](diffhunk://#diff-a12ae5c885b0673c0ff6f70c2670886907590d624626e07da4c52e01aeaf56a4L30-R43): Replaced inline PowerShell scripts with the `PSModule/GitHub-Script@v1` module to use the built in functionality of the GitHub PowerShell module.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84-R84): Updated the `Get-IssueFormData` module from version `v0` to `v1`.


## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
