### PR TITLE
🩹 [Patch]: Fix path separator in action.yml for script execution

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,4 +28,4 @@ runs:
         ShowOutput: true
         Script: |
           # Get-IssueFormData
-          ${{ github.action_path }}\scripts\main.ps1
+          ${{ github.action_path }}/scripts/main.ps1


### PR DESCRIPTION
## Description

This pull request includes a small change to the `action.yml` file. The change corrects the file path for the `main.ps1` script to use forward slashes instead of backslashes.

* `action.yml`:
  * Updated the script path from `${{ github.action_path }}\scripts\main.ps1` to `${{ github.action_path }}/scripts/main.ps1`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
