### PR TITLE
🩹 [Patch]: Make outputs not break line

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -5,12 +5,14 @@
 [CmdletBinding()]
 param()
 
+$PSStyle.OutputRendering = 'Ansi'
+
 LogGroup 'Issue Body - Raw' {
     Write-Output $env:GITHUB_ACTION_INPUT_IssueBody
 }
 
 LogGroup 'Issue Body - Object' {
     $data = $env:GITHUB_ACTION_INPUT_IssueBody | ConvertFrom-IssueForm
-    $data | Format-List
+    $data | Format-List | Out-String
     Set-GitHubOutput -Name 'data' -Value $data
 }


### PR DESCRIPTION
## Description

This pull request includes changes to the `scripts/main.ps1` file to improve the formatting and output rendering of the script. The most important changes include setting the output rendering style to 'Ansi' and ensuring the formatted list is converted to a string before being output.

Improvements to output formatting:

* `scripts/main.ps1`:
  * Set `$PSStyle.OutputRendering` to 'Ansi' to ensure proper output rendering.
  * Modified the pipeline to convert the formatted list to a string using `Out-String` before outputting it.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
