### PR TITLE
🪲 [Fix]: Disable token on the script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,7 @@ runs:
       env:
         GITHUB_ACTION_INPUT_IssueBody: ${{ inputs.IssueBody }}
       with:
+        Token: ''
         ShowOutput: true
         Script: |
           # Get-IssueFormData

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -5,8 +5,6 @@
 [CmdletBinding()]
 param()
 
-$PSStyle.OutputRendering = 'Ansi'
-
 LogGroup 'Issue Body - Raw' {
     Write-Output $env:GITHUB_ACTION_INPUT_IssueBody
 }


### PR DESCRIPTION
## Description

This pull request includes minor updates to the GitHub Action by disabling the logon functionality by providing an empty token.

Updates to GitHub Actions configuration:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R28): Added a default empty value for the `Token` parameter under `with:` to ensure that the action does not require.

Simplifications to PowerShell script:

* [`scripts/main.ps1`](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011L8-L9): Removed `$PSStyle.OutputRendering = 'Ansi'` to simplify the script and potentially avoid unnecessary styling configuration. This is included in the `GitHub` PowerShell module used via `GitHub-Script`.
